### PR TITLE
Fix AncestorsOrSelf<ModelType> returning null in v15

### DIFF
--- a/src/Umbraco.Community.RollbackPreviewer/Services/RollBackContentFinder.cs
+++ b/src/Umbraco.Community.RollbackPreviewer/Services/RollBackContentFinder.cs
@@ -138,9 +138,12 @@ namespace Umbraco.Community.RollbackPreviewer.Services
 
                 try
                 {
-                    // Set the new culture on the variation accessor and push it into the request pipeline
-                    _variationContextAccessor.VariationContext = new VariationContext(culture);
-                    frequest.SetCulture(culture);
+                    if (culture != null)
+                    {
+                        // Set the new culture on the variation accessor and push it into the request pipeline
+                        _variationContextAccessor.VariationContext = new VariationContext(culture);
+                        frequest.SetCulture(culture);
+                    }
                     // Copy the changes from the version
                     content.CopyFrom(version, culture);
                 }


### PR DESCRIPTION
This relates to https://github.com/Rockerby/Umbraco.Community.RollbackPreviewer/issues/25

When we load in the page through the content finder we set the culture on the VariationContext, even if it's null. This then causes an issue later down the line as it resolves itself to an empty string, and then bottoms out when filtering the content. This is only an issue on v15 and if the document (the ancestor, not the actual page) is allowed to vary by culture.

The bit of code within Umbaco that we're concerned with is in [PublishedContentStatusFilteringService](https://github.com/umbraco/Umbraco-CMS/blob/5d9d94a0e8340391bbf70ff6d0fc665dab8b38df/src/Umbraco.Core/Services/PublishStatus/PublishedContentStatusFilteringService.cs#L28) and then ultimately in the WhereIsInvariantOrHasCulture method.

Tested on v13 and v15 with a combination of vary by culture and not.

Can you give it a quick once over with your specific site you were having trouble with please @MMasey ?