### PR TITLE
Fix missing/null properties in rollback preview

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -9,8 +9,8 @@
 
 Enhance Umbraco's rollback functionality with visual rollback previews. This extension builds ontop of the existing Umbraco Rollback modal and allows for the JSON diff to be viewed as well as the visual diff. **NEW FEATURE!** You can now share the preview as a publicly available URL. With configurable outputs for a secret key to lock this down, and have an expiration time on the URL, this is the perfect way to share content with externals.
 
-<img alt="Visual difference" src="https://github.com/Rockerby/Umbraco.Community.RollbackPreviewer/blob/develop/docs/screenshots/visual_diff.png"> 
-<img alt="JSON difference" src="https://github.com/Rockerby/Umbraco.Community.RollbackPreviewer/blob/develop/docs/screenshots/json_diff.png">
+<img alt="Visual difference" src="https://github.com/Rockerby/Umbraco.Community.RollbackPreviewer/blob/main/docs/screenshots/visual_diff.png"> 
+<img alt="JSON difference" src="https://github.com/Rockerby/Umbraco.Community.RollbackPreviewer/blob/main/docs/screenshots/json_diff.png">
 
 ## Installation
 

--- a/src/Umbraco.Community.RollbackPreviewer/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Community.RollbackPreviewer/Extensions/PublishedContentExtensions.cs
@@ -183,12 +183,17 @@ namespace Umbraco.Community.RollbackPreviewer.Extensions
             public PublishedPropertyWrapper(IPublishedContent content,  IPublishedPropertyType propertyType, IProperty property, string? culture, bool isPreviewing)
                 : this(propertyType, PropertyCacheLevel.Unknown) // cache level is ignored
             {
-                _sourceValue = property?.GetValue(culture);
+                // IProperty.GetValue requires a null culture for invariant properties and the
+                // matching culture for variant ones; passing the wrong one returns null.
+                var propertyCulture = propertyType.VariesByCulture() ? culture : null;
+                _sourceValue = property?.GetValue(propertyCulture);
 
-                if (_sourceValue == null)
+                if (_sourceValue == null && property != null)
                 {
-                    // Block properties return null for GetValue...
-                    _sourceValue = property?.Values?.FirstOrDefault()?.EditedValue;
+                    var matchingValue = property.Values.FirstOrDefault(v =>
+                        string.Equals(v.Culture ?? string.Empty, propertyCulture ?? string.Empty, StringComparison.OrdinalIgnoreCase)
+                        && string.IsNullOrEmpty(v.Segment));
+                    _sourceValue = matchingValue?.EditedValue ?? matchingValue?.PublishedValue;
                 }
 
                 _content = content;

--- a/src/Umbraco.Community.RollbackPreviewer/Services/RollBackContentFinder.cs
+++ b/src/Umbraco.Community.RollbackPreviewer/Services/RollBackContentFinder.cs
@@ -154,8 +154,6 @@ namespace Umbraco.Community.RollbackPreviewer.Services
                         _variationContextAccessor.VariationContext = new VariationContext(culture);
                         frequest.SetCulture(culture);
                     }
-                    // Copy the changes from the version
-                    content.CopyFrom(version, culture);
                 }
                 catch (CultureNotFoundException cnfe)
                 {
@@ -163,8 +161,16 @@ namespace Umbraco.Community.RollbackPreviewer.Services
                     return false;
                 }
 
-                // Convert the IContent to IPublishedContent.
-                IPublishedContent? pubContent = _publishedContentConverter.ToPublishedContent(content, culture)?
+                // Convert the version's IContent directly to IPublishedContent.
+                // We deliberately do NOT call content.CopyFrom(version, culture) here:
+                // when the requested versionId matches content.VersionId (the latest
+                // draft, which is what the share-URL controller uses), CopyFrom's
+                // internal flag (content.Id == other.Id && content.VersionId == other.VersionId)
+                // makes it copy PublishedValue rather than EditedValue, silently
+                // stripping any unpublished edits from the preview. Using the
+                // version's IContent straight from IContentVersionService.GetAsync
+                // gives us the correct EditedValue per property.
+                IPublishedContent? pubContent = _publishedContentConverter.ToPublishedContent(version, culture, isPreview: true)?
                     .CreateModel(_publishedModelFactory);
 
                 if (pubContent == null)


### PR DESCRIPTION
Convert the version's IContent directly to IPublishedContent instead of calling content.CopyFrom(version, culture) — when versionId equals content.VersionId (the share-URL flow), CopyFrom copies PublishedValue rather than EditedValue and silently strips unpublished edits.

In PublishedPropertyWrapper, pass null culture for invariant properties and the matching culture for variant ones, and fall back to a culture+segment matched value with EditedValue ?? PublishedValue when GetValue returns null.